### PR TITLE
Investigate vercel deployment not found error

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,3 @@
+libgl1
+libglib2.0-0
+ffmpeg

--- a/people_counter.py
+++ b/people_counter.py
@@ -748,7 +748,10 @@ class PeopleCounter:
             st.session_state.webcam_initialized = False
             
             # Clear any existing video capture objects
-            cv2.destroyAllWindows()
+            try:
+                cv2.destroyAllWindows()
+            except Exception:
+                pass
             
             st.success("🛑 Webcam stopped successfully!")
             

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit>=1.28.0
-opencv-python>=4.8.0
+opencv-python-headless>=4.8.0
 ultralytics>=8.0.0
 numpy>=1.24.0
 scipy>=1.11.0


### PR DESCRIPTION
Fixes `cv2` import error on Streamlit Cloud by using headless OpenCV and adding system dependencies.

The `opencv-python` package requires GUI libraries that are not present in headless environments like Streamlit Cloud, leading to an `ImportError`. Switching to `opencv-python-headless` and providing necessary system libraries via `packages.txt` resolves this. A `try-except` block around `cv2.destroyAllWindows()` further ensures compatibility in headless mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7e828de-54cf-40bc-9b2e-8259cba30d37">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7e828de-54cf-40bc-9b2e-8259cba30d37">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

